### PR TITLE
refactor: add jdk indexing as a subcommand to indexer

### DIFF
--- a/classfile-fingerprint/pom.xml
+++ b/classfile-fingerprint/pom.xml
@@ -131,6 +131,30 @@
         <artifactId>maven-plugin-plugin</artifactId>
         <version>3.9.0</version>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <configuration>
+          <createDependencyReducedPom>false</createDependencyReducedPom>
+          <transformers>
+            <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+              <manifestEntries>
+                <Main-Class>io.github.algomaster99.terminator.index.Index</Main-Class>
+                <Multi-Release>false</Multi-Release>
+              </manifestEntries>
+            </transformer>
+          </transformers>
+        </configuration>
+        <executions>
+          <execution>
+            <id>shade</id>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <phase>package</phase>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/classfile-fingerprint/src/main/java/io/github/algomaster99/terminator/index/Index.java
+++ b/classfile-fingerprint/src/main/java/io/github/algomaster99/terminator/index/Index.java
@@ -1,0 +1,21 @@
+package io.github.algomaster99.terminator.index;
+
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+        name = "index",
+        mixinStandardHelpOptions = true,
+        subcommands = {JdkIndexer.class},
+        description = "Create an index of the classfiles")
+public class Index implements Callable<Integer> {
+    @Override
+    public Integer call() throws Exception {
+        new CommandLine(this).usage(System.out);
+        return 0;
+    }
+
+    public static void main(String[] args) {
+        new CommandLine(new Index()).execute(args);
+    }
+}

--- a/classfile-fingerprint/src/main/java/io/github/algomaster99/terminator/index/JdkIndexer.java
+++ b/classfile-fingerprint/src/main/java/io/github/algomaster99/terminator/index/JdkIndexer.java
@@ -1,0 +1,114 @@
+package io.github.algomaster99.terminator.index;
+
+import io.github.algomaster99.terminator.commons.fingerprint.JdkClass;
+import io.github.algomaster99.terminator.commons.fingerprint.ParsingHelper;
+import io.github.algomaster99.terminator.commons.fingerprint.classfile.ClassFileAttributes;
+import io.github.algomaster99.terminator.commons.fingerprint.classfile.ClassfileVersion;
+import io.github.algomaster99.terminator.commons.fingerprint.classfile.HashComputer;
+import io.github.algomaster99.terminator.commons.fingerprint.provenance.Jdk;
+import io.github.algomaster99.terminator.commons.fingerprint.provenance.Provenance;
+import java.io.File;
+import java.nio.ByteBuffer;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+        name = "jdk",
+        mixinStandardHelpOptions = true,
+        description = "Create an index of the classfiles in JDK")
+public class JdkIndexer implements Callable<Integer> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Jdk.class);
+
+    @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
+    private IndexFile indexFile;
+
+    private static class IndexFile {
+        @CommandLine.Option(
+                names = {"-o", "--output"},
+                description = "Use this option if you want to create a new file with classfiles")
+        File output;
+
+        @CommandLine.Option(
+                names = {"-i", "--input"},
+                description = "Use this option if you want to use an existing file with classfiles")
+        File input;
+    }
+
+    @CommandLine.Option(
+            names = {"--algorithm"},
+            description = "The algorithm to use for computing the hash",
+            defaultValue = "SHA-256",
+            required = true)
+    private String algorithm;
+
+    @Override
+    public Integer call() throws Exception {
+        if (indexFile.input != null) {
+            Map<String, List<Provenance>> currentReferenceProvenance =
+                    ParsingHelper.deserializeFingerprints(indexFile.input.toPath());
+            Map<String, List<Provenance>> updatedReferenceProvenance =
+                    createOrMergeProvenances(currentReferenceProvenance);
+            ParsingHelper.serialiseFingerprints(updatedReferenceProvenance, indexFile.input.toPath());
+            return 0;
+        }
+        if (indexFile.output != null) {
+            Map<String, List<Provenance>> updatedReferenceProvenance = createOrMergeProvenances(new HashMap<>());
+            ParsingHelper.serialiseFingerprints(updatedReferenceProvenance, indexFile.output.toPath());
+            return 0;
+        }
+        throw new IllegalArgumentException("Either --input or --output must be specified");
+    }
+
+    public Map<String, List<Provenance>> createOrMergeProvenances(Map<String, List<Provenance>> referenceProvenance) {
+        List<JdkClass> jdkClasses = io.github.algomaster99.terminator.commons.fingerprint.JdkIndexer.listJdkClasses();
+        jdkClasses.forEach(resource -> {
+            try {
+                byte[] classfileBytes = getBytesFromBuffer(resource.bytes());
+                String classfileVersion = ClassfileVersion.getVersion(classfileBytes);
+                String hash = HashComputer.computeHash(classfileBytes, algorithm);
+                referenceProvenance.computeIfAbsent(
+                        resource.name(),
+                        k -> new ArrayList<>(
+                                List.of((new Jdk(new ClassFileAttributes(classfileVersion, hash, algorithm))))));
+                referenceProvenance.computeIfPresent(resource.name(), (k, v) -> {
+                    // TODO: should be removed after https://github.com/ASSERT-KTH/sbom.exe/issues/96 is fixed
+                    if (v.stream()
+                            .anyMatch(jdk -> jdk.classFileAttributes().hash().equals(hash))) {
+                        return v;
+                    }
+                    v.add(new Jdk(new ClassFileAttributes(classfileVersion, hash, algorithm)));
+                    return v;
+                });
+            } catch (NoSuchAlgorithmException e) {
+                LOGGER.error("Failed to compute hash with algorithm: " + algorithm, e);
+                throw new RuntimeException(e);
+            } catch (Exception e) {
+                LOGGER.error("Failed to compute hash for: " + resource, e);
+            }
+        });
+        return referenceProvenance;
+    }
+
+    /**
+     * Converts a bytebuffer to a byte array. If the buffer has an array, it returns it, otherwise it copies the bytes. This is needed because the buffer is not guaranteed to have an array.
+     * See {@link java.nio.ByteBuffer#hasArray()} and {@link java.nio.DirectByteBuffer}.
+     * @param buffer  the buffer to convert
+     * @return  the byte array
+     */
+    private static byte[] getBytesFromBuffer(ByteBuffer buffer) {
+        if (buffer.hasArray()) {
+            return buffer.array();
+        }
+        byte[] bytes = new byte[buffer.remaining()];
+        buffer.get(bytes);
+        return bytes;
+    }
+}

--- a/classfile-fingerprint/src/main/java/io/github/algomaster99/terminator/index/JdkIndexer.java
+++ b/classfile-fingerprint/src/main/java/io/github/algomaster99/terminator/index/JdkIndexer.java
@@ -67,7 +67,7 @@ public class JdkIndexer implements Callable<Integer> {
         throw new IllegalArgumentException("Either --input or --output must be specified");
     }
 
-    public Map<String, List<Provenance>> createOrMergeProvenances(Map<String, List<Provenance>> referenceProvenance) {
+    private Map<String, List<Provenance>> createOrMergeProvenances(Map<String, List<Provenance>> referenceProvenance) {
         List<JdkClass> jdkClasses = io.github.algomaster99.terminator.commons.fingerprint.JdkIndexer.listJdkClasses();
         jdkClasses.forEach(resource -> {
             try {

--- a/classfile-fingerprint/src/main/java/io/github/algomaster99/terminator/index/JdkIndexer.java
+++ b/classfile-fingerprint/src/main/java/io/github/algomaster99/terminator/index/JdkIndexer.java
@@ -44,7 +44,8 @@ public class JdkIndexer implements Callable<Integer> {
 
     @CommandLine.Option(
             names = {"--algorithm"},
-            description = "The algorithm to use for computing the hash",
+            description =
+                    "The algorithm to use for computing the hash. See https://docs.oracle.com/en/java/javase/17/docs/specs/security/standard-names.html#messagedigest-algorithms.",
             defaultValue = "SHA-256",
             required = true)
     private String algorithm;

--- a/classfile-fingerprint/src/test/java/io/github/algomaster99/terminator/index/JdkIndexerTest.java
+++ b/classfile-fingerprint/src/test/java/io/github/algomaster99/terminator/index/JdkIndexerTest.java
@@ -2,9 +2,13 @@ package io.github.algomaster99.terminator.index;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.github.algomaster99.terminator.commons.fingerprint.ParsingHelper;
+import io.github.algomaster99.terminator.commons.fingerprint.provenance.Provenance;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -25,5 +29,20 @@ class JdkIndexerTest {
 
         // assert
         assertThat(contentFirst).isEqualTo(contentSecond);
+    }
+
+    @Test
+    void useMD5asAlgorithm(@TempDir Path tempDir) {
+        // arrange
+        Path indexFile = tempDir.resolve("jdk.json");
+
+        // act
+        String[] args = {"jdk", "-o", indexFile.toString(), "--algorithm", "MD5"};
+        Index.main(args);
+
+        // assert
+        Map<String, List<Provenance>> referenceProvenance = ParsingHelper.deserializeFingerprints(indexFile);
+        referenceProvenance.forEach((key, value) ->
+                assertThat(value.get(0).classFileAttributes().algorithm()).isEqualTo("MD5"));
     }
 }

--- a/classfile-fingerprint/src/test/java/io/github/algomaster99/terminator/index/JdkIndexerTest.java
+++ b/classfile-fingerprint/src/test/java/io/github/algomaster99/terminator/index/JdkIndexerTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 class JdkIndexerTest {
     @Test
-    void jdkIndexShouldBeDeterministic(@TempDir Path tempDir) throws IOException {
+    void jdkIndexShouldBeDeterministic_irrespectiveOfTheJDK(@TempDir Path tempDir) throws IOException {
         // arrange
         Path indexFile = tempDir.resolve("jdk.json");
 

--- a/classfile-fingerprint/src/test/java/io/github/algomaster99/terminator/index/JdkIndexerTest.java
+++ b/classfile-fingerprint/src/test/java/io/github/algomaster99/terminator/index/JdkIndexerTest.java
@@ -1,0 +1,29 @@
+package io.github.algomaster99.terminator.index;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class JdkIndexerTest {
+    @Test
+    void jdkIndexShouldBeDeterministic(@TempDir Path tempDir) throws IOException {
+        // arrange
+        Path indexFile = tempDir.resolve("jdk.json");
+
+        // act
+        String[] argsFirst = {"jdk", "-o", indexFile.toString()};
+        Index.main(argsFirst);
+        String contentFirst = Files.readString(indexFile);
+
+        String[] argsSecond = {"jdk", "-i", indexFile.toString()};
+        Index.main(argsSecond);
+        String contentSecond = Files.readString(indexFile);
+
+        // assert
+        assertThat(contentFirst).isEqualTo(contentSecond);
+    }
+}

--- a/terminator-commons/src/main/java/io/github/algomaster99/terminator/commons/fingerprint/provenance/Jdk.java
+++ b/terminator-commons/src/main/java/io/github/algomaster99/terminator/commons/fingerprint/provenance/Jdk.java
@@ -1,7 +1,9 @@
 package io.github.algomaster99.terminator.commons.fingerprint.provenance;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.github.algomaster99.terminator.commons.fingerprint.classfile.ClassFileAttributes;
 
+@JsonDeserialize(as = Jdk.class)
 public record Jdk(ClassFileAttributes classFileAttributes) implements Provenance {
     @Override
     public ClassFileAttributes classFileAttributes() {

--- a/terminator-commons/src/main/java/io/github/algomaster99/terminator/commons/fingerprint/provenance/Provenance.java
+++ b/terminator-commons/src/main/java/io/github/algomaster99/terminator/commons/fingerprint/provenance/Provenance.java
@@ -22,11 +22,10 @@ class ProvenanceDeserializer extends JsonDeserializer<Provenance> {
         Class<? extends Provenance> instanceClass = null;
         if (root.has("path")) {
             instanceClass = Jar.class;
-        } else {
+        } else if (root.has("groupId")) {
             instanceClass = Maven.class;
-        }
-        if (instanceClass == null) {
-            return null;
+        } else {
+            instanceClass = Jdk.class;
         }
         return mapper.convertValue(root, instanceClass);
     }


### PR DESCRIPTION
Add `jdk` as a subcommand for indexing.